### PR TITLE
Add GitHub action to build container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build container
+
+on:
+  push:
+
+jobs:
+  run:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true # push to registry
+          pull: true # always fetch the latest base images
+          tags: ghcr.io/taskforcesh/taskforce-connector:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        # Temp cache move fix until https://github.com/docker/buildx/pull/535 is released
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,5 @@ CMD pm2-runtime taskforce --web 80 -- -n "${TASKFORCE_CONNECTION}" --team "${TAS
 
 HEALTHCHECK --interval=30s --timeout=30s \
   --start-period=5s --retries=3 CMD curl -f http://localhost || exit 1
+
+LABEL org.opencontainers.image.source="https://github.com/taskforcesh/taskforce-connector"


### PR DESCRIPTION
This PR adds a GitHub workflow that, on every push, rebuilds a Docker image and pushes it to the GitHub container registry.

Note: for this to work, someone with write access to this repo should create a Personal Access Token and set it as repo secret under the name `CR_PAT`. Also, Container Registry needs to be enabled first: https://docs.github.com/en/packages/guides/enabling-improved-container-support#enabling-github-container-registry-for-your-organization-account