### PR TITLE
Roll back to Node 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:12-alpine
 
 RUN apk --no-cache add curl
 


### PR DESCRIPTION
Sorry, my commit yesterday broke the image. PM2@3 doesn't work well with Node 14 (and PM2@4 has other issues) - hence the rollback to Node 12.