### PR TITLE
feat: add sentinel password support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Call the tool and get a help on the options:
     -h, --host [host]           redis host [localhost] (default: "localhost")
     -d, --database [db]         redis database [0] (default: "0")
     --passwd [passwd]           redis password
+    --spasswd [spasswd]         redis sentinel password
     -u, --uri [uri]             redis uri
     --team [team]               specify team where to put the connection
     -b, --backend [host]        backend domain [api.taskforce.sh] (default: "wss://api.taskforce.sh")
@@ -69,13 +70,14 @@ Sentinel Example:
 Note: You can also specify the following with environment variables.
 
 ```bash
-token     TASKFORCE_TOKEN
-port      REDIS_PORT
-host      REDIS_HOST
-password  REDIS_PASSWD
-uri       REDIS_URI
-sentinels REDIS_SENTINELS
-master    REDIS_MASTER
+token                 TASKFORCE_TOKEN
+port                  REDIS_PORT
+host                  REDIS_HOST
+password              REDIS_PASSWD
+sentinel-password     REDIS_SENTINEL_PASSWD
+uri                   REDIS_URI
+sentinels             REDIS_SENTINELS
+master                REDIS_MASTER
 ```
 
 ## Secured TLS Connections

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ program
   )
   .option("-d, --database [db]", "redis database [0]", "0")
   .option("--passwd [passwd]", "redis password", process.env.REDIS_PASSWD)
+  .option(
+    "--spasswd [spasswd]",
+    "redis sentinel password",
+    process.env.REDIS_SENTINEL_PASSWD
+  )
   .option("-u, --uri [uri]", "redis uri", process.env.REDIS_URI)
   .option("--team [team]", "specify team where to put the connection")
   .option(
@@ -86,6 +91,7 @@ lastestVersion(name).then(function (newestVersion) {
     port: program.port,
     host: program.host,
     password: program.passwd,
+    sentinelPassword: program.spasswd,
     db: program.database,
     uri: program.uri,
     tls: program.tls

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -358,6 +358,7 @@ function redisOptsFromConnection(connection: Connection): RedisOptions {
       "host",
       "family",
       "password",
+      "sentinelPassword",
       "db",
       "tls",
       "sentinels",


### PR DESCRIPTION
Added a `spasswd` parameter which sets the `sentinelPassword` for ioredis.

Can also be set by using the `REDIS_SENTINEL_PASSWD` env variable.