### PR TITLE
Fixed getting queues on Redis Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ nodes                 REDIS_NODES (comma separated list of nodes for Redis Clust
 
 Note for Redis Cluster: You may also need to specify following with environment variables.
 ```bash
-Cluster Username             REDIS_CLUSTER_USERNAME
-Cluster Password             REDIS_CLUSTER_PASSWORD
-Cluster TLS Certificate      REDIS_CLUSTER_PASSWORD
+Cluster TLS Certificate      REDIS_CLUSTER_TLS
 ```
 
 If your redis cluster still cannot connect due to failing certificate validation, you may need to pass this env to skip cert validation.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Call the tool and get a help on the options:
     -s, --sentinels [host:port] comma-separated list of sentinel host/port pairs
     -m, --master [name]         name of master node used in sentinel configuration
     -h, --help                  output usage information
+    --nodes [nodes]             comma-separated list of cluster nodes uris to connect to (Redis Cluster)
 ```
 
 Example:
@@ -77,7 +78,20 @@ sentinel-password     REDIS_SENTINEL_PASSWD
 uri                   REDIS_URI
 sentinels             REDIS_SENTINELS (comma separated list of sentinels)
 master                REDIS_MASTER
-nodes                 REDIS_NODES (comma separated list of nodes)
+nodes                 REDIS_NODES (comma separated list of nodes for Redis Cluster)
+```
+
+
+Note for Redis Cluster: You may also need to specify following with environment variables.
+```bash
+Cluster Username             REDIS_CLUSTER_USERNAME
+Cluster Password             REDIS_CLUSTER_PASSWORD
+Cluster TLS Certificate      REDIS_CLUSTER_PASSWORD
+```
+
+If your redis cluster still cannot connect due to failing certificate validation, you may need to pass this env to skip cert validation.
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED="0"
 ```
 
 ## Secured TLS Connections

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ program
   .option(
     "--nodes <nodes>",
     "comma-separated list of cluster nodes uris to connect to",
-    process.env.REDIS_NODES ? process.env.REDIS_NODES.split(",") : undefined
+    process.env.REDIS_NODES ? process.env.REDIS_NODES : undefined
   )
   .parse(process.argv);
 
@@ -113,7 +113,7 @@ lastestVersion(name).then(function (newestVersion) {
   const { Socket } = require("./dist/socket");
   Socket(program.name, program.backend, program.token, connection, {
     team: program.team,
-    nodes: program.nodes,
+    nodes: program.nodes ? program.nodes.split(",") : undefined,
   });
 });
 

--- a/lib/queue-factory.ts
+++ b/lib/queue-factory.ts
@@ -1,6 +1,6 @@
 import { Redis, Cluster, RedisOptions } from "ioredis";
 
-import { QueueType, getQueueType } from "./utils";
+import { QueueType, getQueueType, redisOptsFromUrl } from "./utils";
 import { Queue } from "bullmq";
 import * as Bull from "bull";
 import { BullMQResponders, BullResponders } from "./responders";
@@ -104,11 +104,12 @@ export function getRedisClient(
 ) {
   if (!redisClients[type]) {
     if (clusterNodes && clusterNodes.length) {
+      const { username, password } = redisOptsFromUrl(clusterNodes[0])
       redisClients[type] = new Redis.Cluster(clusterNodes, {
         ...redisOpts, 
         redisOptions: {
-          username: process.env.REDIS_CLUSTER_USERNAME,
-          password: process.env.REDIS_CLUSTER_PASSWORD,
+          username,
+          password,
           tls: process.env.REDIS_CLUSTER_TLS ? {
               cert: Buffer.from(process.env.REDIS_CLUSTER_TLS ?? '', 'base64').toString('ascii')
           } : undefined,

--- a/lib/queue-factory.ts
+++ b/lib/queue-factory.ts
@@ -100,7 +100,7 @@ export async function getRedisInfo(
 export function getRedisClient(
   redisOpts: RedisOptions,
   type: "bull" | "bullmq",
-  clusterNodes?: string[],
+  clusterNodes?: string[]
 ) {
   if (!redisClients[type]) {
     if (clusterNodes && clusterNodes.length) {

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -1,10 +1,9 @@
 import { RedisOptions } from "ioredis";
 import { pick } from "lodash";
-import * as url from "url";
 import { getCache, updateQueuesCache, queueKey } from "./queues-cache";
 import { WebSocketClient } from "./ws-autoreconnect";
 import { execRedisCommand, getRedisInfo, ping } from "./queue-factory";
-import { getQueueType } from "./utils";
+import { getQueueType, redisOptsFromUrl } from "./utils";
 import { Integration } from "./interfaces/integration";
 
 const { version } = require(`${__dirname}/../package.json`);
@@ -259,24 +258,4 @@ function redisOptsFromConnection(connection: Connection): RedisOptions {
     return delay;
   };
   return opts;
-}
-
-function redisOptsFromUrl(urlString: string) {
-  const redisOpts: RedisOptions = {};
-  try {
-    const redisUrl = url.parse(urlString);
-    redisOpts.port = parseInt(redisUrl.port) || 6379;
-    redisOpts.host = redisUrl.hostname;
-    redisOpts.db = redisUrl.pathname
-      ? parseInt(redisUrl.pathname.split("/")[1])
-      : 0;
-    if (redisUrl.auth) {
-      const username = redisUrl.auth.split(":")[0];
-      redisOpts.username = username ? username : undefined;
-      redisOpts.password = redisUrl.auth.split(":")[1];
-    }
-  } catch (e) {
-    throw new Error(e.message);
-  }
-  return redisOpts;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,7 @@
 import { Redis, Cluster } from "ioredis";
 export type QueueType = "bull" | "bullmq" | "bullmq-pro";
+import { RedisOptions } from "ioredis";
+import * as url from "url";
 
 export const getQueueType = async (
   queueName: string,
@@ -27,3 +29,24 @@ export const getQueueType = async (
   // otherwise, it is a bull queue type.
   return "bull";
 };
+
+
+export function redisOptsFromUrl(urlString: string) {
+  const redisOpts: RedisOptions = {};
+  try {
+    const redisUrl = url.parse(urlString);
+    redisOpts.port = parseInt(redisUrl.port) || 6379;
+    redisOpts.host = redisUrl.hostname;
+    redisOpts.db = redisUrl.pathname
+      ? parseInt(redisUrl.pathname.split("/")[1])
+      : 0;
+    if (redisUrl.auth) {
+      const username = redisUrl.auth.split(":")[0];
+      redisOpts.username = username ? username : undefined;
+      redisOpts.password = redisUrl.auth.split(":")[1];
+    }
+  } catch (e) {
+    throw new Error(e.message);
+  }
+  return redisOpts;
+}


### PR DESCRIPTION
SCAN command or Redis Cluster is jumping around the Nodes.

In my testing when running SCAN command via `Medis` app, then the SCAN worked correctly, returning non `'0'` cursor.

While testing ioredis, it seems that at random pages you get cursor `'0'` so the search ends too early. The guess is that it jumped to different node for the SCAN. 

Now it will run scan on each of nodes. 