### PR TITLE
Publish Connector from internal registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM node:20-alpine
 
+ARG GITHUB_PACKAGES_TOKEN
+
 RUN apk --no-cache add curl
 
-RUN yarn global add --ignore-optional taskforce-connector pm2@5.2.0 && yarn cache clean
+RUN set -euxo pipefail \
+  && test -n "$GITHUB_PACKAGES_TOKEN" \
+  && printf "@magicaltome:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n" "$GITHUB_PACKAGES_TOKEN" > ~/.npmrc \
+  && yarn global add --ignore-optional @magicaltome/taskforce-connector pm2@5.2.0 \
+  && yarn cache clean \
+  && rm -f ~/.npmrc
 
 CMD pm2-runtime taskforce -- -n "${TASKFORCE_CONNECTION}" --team "${TASKFORCE_TEAM}" `([ "$REDIS_USE_TLS" == "1" ] && echo --tls)`
 

--- a/lib/cmd.ts
+++ b/lib/cmd.ts
@@ -91,7 +91,7 @@ export const run = (name: string, version: string) => {
         chalk.yellow(
           "New version " +
             newestVersion +
-            " of taskforce available, please upgrade with yarn global add taskforce-connector"
+            " of Taskforce Connector available, please upgrade with yarn global add @magicaltome/taskforce-connector"
         )
       );
     }

--- a/lib/responders/bull-responders.ts
+++ b/lib/responders/bull-responders.ts
@@ -52,7 +52,7 @@ async function respondJobCommand(
       await job.update(data.data);
     default:
       console.error(
-        `Missing command ${data.cmd}. Too old version of taskforce-connector?`
+        `Missing command ${data.cmd}. Too old version of Taskforce Connector?`
       );
   }
   respond(ws, startTime, msg.id);
@@ -150,7 +150,7 @@ async function respondQueueCommand(
       break;
     default:
       console.error(
-        `Missing command ${data.cmd}. Too old version of taskforce-connector?`
+        `Missing command ${data.cmd}. Too old version of Taskforce Connector?`
       );
       respond(ws, msg.id, null);
   }

--- a/lib/responders/bullmq-responders.ts
+++ b/lib/responders/bullmq-responders.ts
@@ -46,7 +46,7 @@ async function respondJobCommand(ws: WebSocketClient, queue: Queue, msg: any) {
       await job.updateData(data.data);
     default:
       console.error(
-        `Missing command ${data.cmd}. Too old version of taskforce-connector?`
+        `Missing command ${data.cmd}. Too old version of Taskforce Connector?`
       );
   }
   respond(ws, startTime, msg.id);
@@ -166,7 +166,7 @@ async function respondQueueCommand(
       break;
     default:
       console.error(
-        `Missing command ${data.cmd}. Too old version of taskforce-connector?`
+        `Missing command ${data.cmd}. Too old version of Taskforce Connector?`
       );
       respond(ws, startTime, msg.id, null);
   }

--- a/lib/version-checker.ts
+++ b/lib/version-checker.ts
@@ -18,14 +18,14 @@ export const versionChecker = async (name: string, version: string) => {
         yellow(
           "New version " +
           newestVersion +
-          " of taskforce available, please upgrade with yarn global add taskforce-connector"
+          " of Taskforce Connector available, please upgrade with yarn global add @magicaltome/taskforce-connector"
         )
       );
     }
   } catch (err) {
     console.error(
       yellow(
-        "Error checking for latest version of taskforce"
+        "Error checking for latest version of Taskforce Connector"
       ),
       err
     );

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "taskforce-connector",
+  "name": "@magicaltome/taskforce-connector",
   "version": "1.36.0",
   "description": "Connects queues to Taskforce",
   "preferGlobal": true,
@@ -16,6 +16,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "dependencies": {
     "bull": "^4.15.1",
     "bullmq": "^5.34.10",


### PR DESCRIPTION
## Summary
- scope the package to @magicaltome and point publishConfig/npm workflow to GitHub Packages
- document the required npm login/token steps and require an auth token during Docker builds
- update CLI messaging and docs so installers use the scoped package name

## Testing
- yarn build
- yarn test *(fails on Node 22 because jest executes the CLI which uses dynamic import without --experimental-vm-modules)*